### PR TITLE
Add the option to hide the "ghost" image when dragging an item

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ npm run dev
 | `propData` (bindable)              | AN ARRAY WITH THE DATA.                                                       | `unknown[]` | YES      | -           |
 | `propItemNumber`                   | THE INITIAL POSITION OF THE ITEM.                                             | `number`    | YES      | `undefined` |
 | `propHoveredItemNumber` (bindable) | THE HOVERED ITEM NUMBER (GENERALY USED TO DO SPECIFIC STYLING WHEN HOVERING). | `number`    | NO       | `-1`        |
+| `propIsImageHidden` | MAKE THE GHOST IMAGE WHEN DRAGGING TRANSPARENT | `boolean`    | NO       | `false`        |
 
 - PROPS OF `MoveIcon`:
 

--- a/src/lib/SortableItem.svelte
+++ b/src/lib/SortableItem.svelte
@@ -5,12 +5,14 @@
 		propItemNumber,
 		propData = $bindable(),
 		propHoveredItemNumber = $bindable(-1), // ANY NON-INTEGER NUMBER
+		propIsImageHidden = false,
 		children,
 		...propRest
 	}: {
 		propItemNumber: number;
 		propData: unknown[];
 		propHoveredItemNumber?: number;
+		propIsImageHidden?: boolean;
 		children: Snippet;
 	} = $props();
 
@@ -42,6 +44,13 @@
 		if (parEvent.dataTransfer === null) return;
 		parEvent.dataTransfer.effectAllowed = 'move';
 		parEvent.dataTransfer.dropEffect = 'move';
+		if (propIsImageHidden) {
+			const transparentImage = new Image();
+			// https://stackoverflow.com/a/40923520
+			transparentImage.src =
+				'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+			parEvent.dataTransfer.setDragImage(transparentImage, 0, 0);
+		}
 		const start = parIndex;
 		parEvent.dataTransfer.setData('text/plain', start.toString());
 	};


### PR DESCRIPTION
The "ghost" image is the image you get under the cursor when you drag an object, it is a translucent copy of the object. Sometimes this behavior is not desired, hence the pull request.

You may learn more about this "ghost" image here: https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/setDragImage

I added an optional boolean prop you can set to get rid of it. The fix is based on this StackOverflow answer: https://stackoverflow.com/a/40923520

I have tested the option in the latest versions of Firefox and Chrome.